### PR TITLE
Do not force the table to use full screen

### DIFF
--- a/src/components/ErrataMainPage.vue
+++ b/src/components/ErrataMainPage.vue
@@ -245,7 +245,6 @@ export default {
   }
   .q-table {
     font-family: 'Montserrat', sans-serif;
-    min-height: 100vh;
   }
   .my-sticky-dynamic {
     /* height or max-height is important */


### PR DESCRIPTION
Partially revert commit 8721d28805a18e13d5931138eecdf26a76940f52.

The downside is, depending on the screen size, empty space may appear below the footer. We could add empty space between the records and the footer instead, but we have decided not to do so here.

Resolves: https://github.com/AlmaLinux/build-system/issues/407